### PR TITLE
upgrade django to 3.2.13 and networkx to 2.6.3

### DIFF
--- a/regparser/index/dependency.py
+++ b/regparser/index/dependency.py
@@ -69,7 +69,7 @@ class Graph(object):
         filename = str(filename)
         if filename not in self._graph:
             self._graph.add_node(filename)
-        return self._graph.node[filename]
+        return self._graph.nodes[filename]
 
     def dependencies(self, filename):
         """What does other nodes does this filename *directly* depend on?"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ decorator==4.4.2         # via ipython, networkx, traitlets
 dj-database-url==0.4.2
 django-click==2.3.0
 django-rq==2.5.1
-django==3.2.12
+django==3.2.13
 djangorestframework==3.11.2
-gitdb==0.6.4              # via gitpython
+gitdb==4.0.9              # via gitpython
 gitpython==3.1.27
 humanfriendly==4.9        # via coloredlogs
 inflection==0.3.1
@@ -27,7 +27,7 @@ ipython==7.16.3            # via ipdb
 jedi==0.10.2              # via ipython
 json-delta==2.0
 lxml==4.6.5
-networkx==2.3
+networkx==2.6.3
 pbr==4.0.0                # via stevedore
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.4        # via ipython
@@ -43,7 +43,7 @@ roman==2.0.0
 rq==1.3.0			  # via django-rq
 simplegeneric==0.8.1      # via ipython
 six==1.11.0
-smmap==0.9.0              # via gitdb
+smmap==5.0.0              # via gitdb
 stevedore==1.13.0
 traitlets==4.3.2          # via ipython
 wcwidth==0.1.7            # via prompt-toolkit

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,7 +17,7 @@ decorator==4.0.11
 dj-database-url==0.4.1
 django-click==1.2.0
 django-rq==0.9.1
-django==1.11
+django==3.2.13
 djangorestframework==3.4
 flake8-blind-except==0.1.1
 flake8-builtins==0.2
@@ -30,7 +30,7 @@ flake8-string-format==0.2.3
 flake8-tuple==0.2.12
 flake8==3.2.1
 freezegun==0.3.8
-gitdb==0.6.4
+gitdb==4.0.9
 gitpython==2.0.2
 httpretty==0.8.14
 humanfriendly==2.4
@@ -44,7 +44,7 @@ json-delta==2.0
 lxml==3.6.0
 mccabe==0.5.3             # via flake8
 mock==2.0.0
-networkx==1.11
+networkx==2.6.3
 pbr==3.0.0
 pep8-naming==0.4.1
 pexpect==4.2.1
@@ -68,7 +68,7 @@ roman==2.0.0
 rq==0.7.1
 simplegeneric==0.8.1
 six==1.10.0
-smmap==0.9.0
+smmap==5.0.0
 stevedore==1.13.0
 testfixtures==4.13.5      # via flake8-isort
 traitlets==4.3.2


### PR DESCRIPTION
Removes deprecated .node method and upgrades django and networkx. Also, fixes small dependency issue with gitpython.

Connected to PR#683 in the e-regs repo. 