### PR TITLE
upgrade-django-3.2.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ decorator==4.4.2         # via ipython, networkx, traitlets
 dj-database-url==0.4.2
 django-click==2.3.0
 django-rq==2.5.1
-django==3.2.13
+django==3.2.14
 djangorestframework==3.11.2
 gitdb==4.0.9              # via gitpython
 gitpython==3.1.27

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,7 +17,7 @@ decorator==4.0.11
 dj-database-url==0.4.1
 django-click==1.2.0
 django-rq==0.9.1
-django==3.2.13
+django==3.2.14
 djangorestframework==3.4
 flake8-blind-except==0.1.1
 flake8-builtins==0.2


### PR DESCRIPTION
Upgrades django to remove [SQL injection vulnerability](https://github.com/fecgov/fec-eregs/issues/695). 

Connected to PR [#695](https://github.com/fecgov/fec-eregs/pull/696)  in the e-regs repo.
