### PR TITLE
Upgrade Django to 3.2.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ decorator==4.4.2         # via ipython, networkx, traitlets
 dj-database-url==0.4.2
 django-click==2.3.0
 django-rq==2.5.1
-django==3.2.14
+django==3.2.15
 djangorestframework==3.11.2
 gitdb==4.0.9              # via gitpython
 gitpython==3.1.27

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,7 +17,7 @@ decorator==4.0.11
 dj-database-url==0.4.1
 django-click==1.2.0
 django-rq==0.9.1
-django==3.2.14
+django==3.2.15
 djangorestframework==3.4
 flake8-blind-except==0.1.1
 flake8-builtins==0.2


### PR DESCRIPTION
Upgrades Django to address [Reflected File Download](https://github.com/fecgov/fec-eregs/issues/703). 

Related PRs:

repo | branch | PR
------ | ------ | ------
fec-eregs | feature/703-django-vulnerability | [eregs #705](https://github.com/fecgov/fec-eregs/pull/705)
regulations-core | django-to-3.2.15 | [core #6](https://github.com/fecgov/regulations-core/pull/6)
regulations-parser | django-3.2.14-=>-3.2.15 | parser #7
regulations-site | upgrade-django-3.2.15 | [site #6](https://github.com/fecgov/regulations-site/pull/6)
