### PR TITLE
Remove unescape code, deprecated in python 3.4

### DIFF
--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Atomic components; probably shouldn't use these directly"""
+import html
 import string
 
 from pyparsing import Optional, ParserElement, Regex, Suppress, Word
@@ -10,7 +11,7 @@ from regparser.grammar.utils import Marker, SuffixMarker, WordBoundaries
 # Set whitespace for all parsing; include unicode whitespace chars
 ParserElement.setDefaultWhitespaceChars(
     string.whitespace +
-    HTMLParser().unescape('&ensp;&emsp;&thinsp;&zwnj;&zwj;&lrm;&rlm;'))
+    html.unescape('&ensp;&emsp;&thinsp;&zwnj;&zwj;&lrm;&rlm;'))
 
 
 lower_p = (

--- a/regparser/tree/xml_parser/preprocessors.py
+++ b/regparser/tree/xml_parser/preprocessors.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import abc
 import functools
+import html
 import logging
 import re
 from copy import deepcopy
@@ -31,12 +32,11 @@ def replace_html_entities(xml_bin_str):
     """XML does not contain entity references for many HTML entities, yet the
     Federal Register XML sometimes contains the HTML entities. Replace them
     here, lest we throw off XML parsing"""
-    parser = HTMLParser()
     match = HTML_RE.search(xml_bin_str)
     while match:
         match_bin = match.group(0)
         match_str = match_bin.decode('utf-8')
-        replacement = parser.unescape(match_str).encode('UTF-8')
+        replacement = html.unescape(match_str).encode('UTF-8')
         logger.debug("Replacing %s with %s in retrieved XML",
                      match_str, replacement)
         xml_bin_str = xml_bin_str.replace(match_bin, replacement)

--- a/regparser/tree/xml_parser/tree_utils.py
+++ b/regparser/tree/xml_parser/tree_utils.py
@@ -7,6 +7,7 @@ from itertools import chain
 
 from lxml import etree
 from six.moves.html_parser import HTMLParser
+import html
 
 from regparser.tree.priority_stack import PriorityStack
 
@@ -147,5 +148,5 @@ def get_node_text_tags_preserved(xml_node):
     node_text = xml_node.text or ''
     node_text += ''.join(etree.tounicode(child) for child in xml_node)
 
-    node_text = HTMLParser().unescape(node_text)
+    node_text = html.unescape(node_text)
     return node_text

--- a/tests/grammar_unified_tests.py
+++ b/tests/grammar_unified_tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import html
 from unittest import TestCase
 
 from six.moves.html_parser import HTMLParser
@@ -57,7 +58,7 @@ class GrammarCommonTests(TestCase):
 
     def _decode(self, txt):
         """Convert from HTML entities"""
-        return HTMLParser().unescape(txt)
+        return html.unescape(txt)
 
     def test_whitespace(self):
         """Verify that various types of whitespace are ignored"""


### PR DESCRIPTION
HTMLParser.unescape was deprecated in python 3.4 and will cause issues with python 3.9 unless setuptools and distlib are pinned, so I switched to html.unescape which replaces this function.

Connected to https://github.com/fecgov/fec-eregs/issues/709